### PR TITLE
Probably resolves bug #2

### DIFF
--- a/php_dataquery/getWorkoutData.php
+++ b/php_dataquery/getWorkoutData.php
@@ -20,7 +20,7 @@ function getNumGyms($db,$userid) {
 
 function getNumClimbs($db,$userid) {
 	//get number of climbs logged
-	$stmt = $db->prepare("SELECT SUM(reps) FROM workout_segments INNER JOIN workouts ON workouts.workout_id = workout_segments.workout_id WHERE workouts.userid=:userid");
+	$stmt = $db->prepare("SELECT IFNULL(SUM(reps),0) FROM workout_segments INNER JOIN workouts ON workouts.workout_id = workout_segments.workout_id WHERE workouts.userid=:userid");
 	$stmt->execute(array(':userid'=>$userid));
 	
 	$result = $stmt->fetch();


### PR DESCRIPTION
This should return 0 for total climbs instead of NULL for new user condition where no workouts have yet been logged. (Bug inadvertently introduced in fix for unnumbered bug reported by Dan H where the dashboard workout count was incorrect.)
